### PR TITLE
Add bypass routes to effect modules

### DIFF
--- a/src/AuxSends.cpp
+++ b/src/AuxSends.cpp
@@ -95,6 +95,9 @@ struct AuxSends : Module {
 		configOutput(CSENDRIGHTOUT_OUTPUT, "Send C Right");
 		configOutput(AUDIOLEFTOUT_OUTPUT, "Audio Left");
 		configOutput(AUDIORIGHTOUT_OUTPUT, "Audio Right");
+
+		configBypass(AUDIOLEFTIN_INPUT, AUDIOLEFTOUT_OUTPUT);
+		configBypass(AUDIORIGHTIN_INPUT, AUDIORIGHTOUT_OUTPUT);
 	}
 
 	void process(const ProcessArgs &args) override {

--- a/src/Bitcrusher.cpp
+++ b/src/Bitcrusher.cpp
@@ -151,6 +151,9 @@ struct Bitcrusher : Module {
 		paramQuantities[SAMPLERATE_PARAM]->module = this;
 		paramQuantities[SAMPLERATE_PARAM]->paramId = SAMPLERATE_PARAM;
 
+		configBypass(AUDIOLEFTIN_INPUT, AUDIOLEFTOUT_OUTPUT);
+		configBypass(AUDIORIGHTIN_INPUT, AUDIORIGHTOUT_OUTPUT);
+
 		filterL.reset();
 		filterR.reset();
 	}

--- a/src/Boost.cpp
+++ b/src/Boost.cpp
@@ -15,6 +15,9 @@ struct Boost : Module {
 		configInput(RIGHTIN_INPUT, "Audio Right");
 		configOutput(LEFTOUT_OUTPUT, "Audio Left");
 		configOutput(RIGHTOUT_OUTPUT, "Audio Right");
+
+		configBypass(LEFTIN_INPUT, LEFTOUT_OUTPUT);
+		configBypass(RIGHTIN_INPUT, RIGHTOUT_OUTPUT);
 	}
 
 	// Cached values

--- a/src/DJFilter.cpp
+++ b/src/DJFilter.cpp
@@ -74,6 +74,9 @@ struct DJFilter : Module {
 
 		configOutput(OUT_L_OUTPUT, "Audio Left");
 		configOutput(OUT_R_OUTPUT, "Audio Right");
+
+		configBypass(INL_INPUT, OUT_L_OUTPUT);
+		configBypass(INR_INPUT, OUT_R_OUTPUT);
 	}
 
 	struct SVF {

--- a/src/Decay.cpp
+++ b/src/Decay.cpp
@@ -15,6 +15,8 @@ struct Decay : Module {
 		configInput(AUDIOIN_INPUT, "Audio");
 		configOutput(DECAYOUT_OUTPUT, "Envelope");
 		configOutput(AUDIOOUT_OUTPUT, "Audio");
+
+		configBypass(AUDIOIN_INPUT, AUDIOOUT_OUTPUT);
 	}
 
 	// --- Cached member variables ---

--- a/src/SeventiesComp.cpp
+++ b/src/SeventiesComp.cpp
@@ -18,6 +18,9 @@ struct SeventiesComp : Module {
 		configInput(AUDIO_R_INPUT, "Audio Right");
 		configOutput(AUDIO_L_OUTPUT, "Audio Left");
 		configOutput(AUDIO_R_OUTPUT, "Audio Right");
+
+		configBypass(AUDIO_L_INPUT, AUDIO_L_OUTPUT);
+		configBypass(AUDIO_R_INPUT, AUDIO_R_OUTPUT);
 	}
 
 	struct Pow10TableRange {

--- a/src/SeventiesEQ.cpp
+++ b/src/SeventiesEQ.cpp
@@ -238,6 +238,9 @@ struct SeventiesEQ : Module {
 		configLight(EQLED_LIGHT_RED, "EQ");
 		configLight(OUTLED_LIGHT_GREEN, "Output");
 		configLight(OUTLED_LIGHT_RED, "Output");
+
+		configBypass(INL_INPUT, OUTL_OUTPUT);
+		configBypass(INR_INPUT, OUTR_OUTPUT);
 	}
 
 	float freqSelectToFreq(int sel, bool isMid) {

--- a/src/Spatializer.cpp
+++ b/src/Spatializer.cpp
@@ -55,6 +55,9 @@ struct Spatializer : Module {
 		configOutput(SENDR_OUTPUT, "Send Right");
 		configOutput(OUTL_OUTPUT, "Audio Left");
 		configOutput(OUTR_OUTPUT, "Audio Right");
+
+		configBypass(INL_INPUT, OUTL_OUTPUT);
+		configBypass(INR_INPUT, OUTR_OUTPUT);
 	}
 	static const int maxDelaySamples = 2880;
 	float delayBufferL[maxDelaySamples] = {};

--- a/src/StereoWidth.cpp
+++ b/src/StereoWidth.cpp
@@ -16,6 +16,9 @@ struct StereoWidth : Module {
 		configInput(INR_INPUT, "Audio Right");
 		configOutput(OUTL_OUTPUT, "Audio Left");
 		configOutput(OUTR_OUTPUT, "Audio Right");
+
+		configBypass(INL_INPUT, OUTL_OUTPUT);
+		configBypass(INR_INPUT, OUTR_OUTPUT);
 	}
 	void process(const ProcessArgs &args) override {
 		// --- Input voltages ---


### PR DESCRIPTION
Same as the core-modules PR — sets ProducerPack effects to pass audio through when bypassed in VCV.

- Adds bypass routing to 9 modules: AuxSends, Bitcrusher, Boost, DJFilter, Decay, SeventiesComp, SeventiesEQ, Spatializer, StereoWidth
- All stereo modules route both L/R channels; Decay routes its single audio path